### PR TITLE
Suppress upstream branch warnings

### DIFF
--- a/clean.zsh
+++ b/clean.zsh
@@ -142,6 +142,9 @@ prompt_clean_chpwd() {
 +vi-git-arrows() {
     if zstyle -T ":vcs_info:${vcs}:clean:arrows" check-head
     then
+        if [[ $(git rev-parse --abbrev-ref --symbolic-full-name) -eq '' ]] then
+          return
+        fi
         local arrows=$($vcs rev-list --left-right --count HEAD...@'{u}')
         local rev=("${(@z)arrows}")
         local left=$rev[1] right=$rev[2]


### PR DESCRIPTION
This checks for an upstream branch before rendering git arrows to avoid warnings like the following:
```
fatal: no upstream configured for branch 'foo'

~/code/bar foo
❯
```