### PR TITLE
fix a missing dollar sign

### DIFF
--- a/clean.plugin.zsh
+++ b/clean.plugin.zsh
@@ -1,11 +1,10 @@
 # Add this folder to the fpath if it is not
 prompt_clean_folder="${0:A:h}"
 if [[ -z "${fpath[(r)$prompt_clean_folder]}" ]]; then
-    fpath+=( prompt_clean_folder )
+    fpath+=( $prompt_clean_folder )
 fi
 
 # Legacy support for those already using antigen
 autoload -U promptinit
 promptinit
 prompt clean
-


### PR DESCRIPTION
It seems like there is a missing dollar sign so that it just added 'prompt_clean_folder' to fpath not the path of 'prompt_clean_folder'.